### PR TITLE
feat: replace relative URL with cloud.google.com

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -60,10 +60,21 @@ function parseSamples(content) {
   }
 }
 
+const BASE_URL = 'https://cloud.google.com/';
+function replaceRelativeLinks(description) {
+  return description.replace(/href="\//g, `href="${BASE_URL}`);
+}
+
 exports.handlers = {
   newDoclet: e => {
     if (sampleCache.size === 0) {
       exports.loadSampleCache();
+    }
+
+    // Any relative links we observe, e.g., /iam, should be assumed to be
+    // relative to cloud.google.com:
+    if (e.doclet.description) {
+      e.doclet.description = replaceRelativeLinks(e.doclet.description);
     }
 
     const examples = e.doclet.examples;

--- a/test/test.js
+++ b/test/test.js
@@ -16,7 +16,7 @@
 
 process.env.SAMPLES_DIRECTORY = './test/fixtures';
 
-const {loadSampleCache} = require('../src');
+const {loadSampleCache, handlers} = require('../src');
 const {describe, it} = require('mocha');
 const assert = require('assert');
 
@@ -26,6 +26,46 @@ describe('jsdoc-region-tag', () => {
       const cache = loadSampleCache();
       const sample = cache.get('bigquery_quickstart');
       assert(sample.includes('async function createDataset () {'));
+    });
+  });
+  describe('handlers', () => {
+    it('does not replace absolute link', () => {
+      const doc = {
+        doclet: {
+          description:
+            'My description <a href="https://github.com/foo">foo link</a>',
+        },
+      };
+      handlers.newDoclet(doc);
+      assert.strictEqual(
+        doc.doclet.description,
+        'My description <a href="https://github.com/foo">foo link</a>'
+      );
+    });
+    it('replaces single link in description', () => {
+      const doc = {
+        doclet: {
+          description: 'My description <a href="/foo">foo link</a>',
+        },
+      };
+      handlers.newDoclet(doc);
+      assert.strictEqual(
+        doc.doclet.description,
+        'My description <a href="https://cloud.google.com/foo">foo link</a>'
+      );
+    });
+    it('replaces multiple links in description', () => {
+      const doc = {
+        doclet: {
+          description:
+            'My description <a href="/foo">foo link</a> hello <a href="/bar">bar link</a>',
+        },
+      };
+      handlers.newDoclet(doc);
+      assert.strictEqual(
+        doc.doclet.description,
+        'My description <a href="https://cloud.google.com/foo">foo link</a> hello <a href="https://cloud.google.com/bar">bar link</a>'
+      );
     });
   });
 });


### PR DESCRIPTION
It's common for APIs to use relative URLs in upstream protos, assuming that the link will be relative to `cloud.google.com`.