### PR TITLE
feat: classdesc can also contain link

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -76,6 +76,9 @@ exports.handlers = {
     if (e.doclet.description) {
       e.doclet.description = replaceRelativeLinks(e.doclet.description);
     }
+    if (e.doclet.classdesc) {
+      e.doclet.classdesc = replaceRelativeLinks(e.doclet.classdesc);
+    }
 
     const examples = e.doclet.examples;
 

--- a/test/test.js
+++ b/test/test.js
@@ -54,6 +54,18 @@ describe('jsdoc-region-tag', () => {
         'My description <a href="https://cloud.google.com/foo">foo link</a>'
       );
     });
+    it('replaces single link in classdesc', () => {
+      const doc = {
+        doclet: {
+          classdesc: 'My description <a href="/foo">foo link</a>',
+        },
+      };
+      handlers.newDoclet(doc);
+      assert.strictEqual(
+        doc.doclet.classdesc,
+        'My description <a href="https://cloud.google.com/foo">foo link</a>'
+      );
+    });
     it('replaces multiple links in description', () => {
       const doc = {
         doclet: {


### PR DESCRIPTION
`classdesc` header can also contain relative links.